### PR TITLE
Permit sections to have relationships

### DIFF
--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -86,8 +86,12 @@ export function makeRelationshipsStrings (
         tag, tagName, definitions
       )
     })
-    // Construct strings for tags in sections
-    category.sections.forEach(section => {
+    // Construct strings for sections
+    Object.entries(category.sections).forEach(([sectionName, section]) => {
+      section._relationships = makeRelationshipsStringsForTag(
+        section, sectionName, definitions
+      )
+      // Construct strings for tags in sections
       Object.entries(section.tags).forEach(([tagName, tag]) => {
         tag._relationships = makeRelationshipsStringsForTag(
           tag, tagName, definitions

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -182,20 +182,32 @@ export function parseConfig (config: string): TagCategory {
   }
 
   // Check that if section exists, it is a list of sections
-  let categorySections: TagCategorySections
+  let categorySections: TagCategorySection[]
   try {
     if ("section" in categoryConfig) {
       categorySections = TagCategorySectionConfigRuntype.check(
         categoryConfig.section
       ).map(sectionConfig => {
-        const name = sectionConfig.name
-        const description = sectionConfig.description
-        // Remove these non-tag properties (this is why they are reserved)
-        delete sectionConfig.name
-        delete sectionConfig.description
+        // Sections are set up sort of weird for a friendly-ish TOML syntax
+        // Properties that are not tags need to be plucked
+        let section: Partial<TagCategorySection> = {}
+        for(const property of <const>[
+          "name",
+          "description",
+          "requires",
+          "similar",
+          "related",
+          "dissimilar",
+          "conflicts",
+          "supersedes",
+        ]) {
+          if (sectionConfig[property] != null)
+            section = { ...section, [property]: sectionConfig[property] }
+          delete sectionConfig[property]
+        }
+
         // Remaining properties are tags
-        const tags = sectionConfig
-        return { name, description, tags }
+        return { ...section, tags: sectionConfig }
       })
       delete categoryConfig.section
     } else {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -41,16 +41,16 @@ const TagCategoryPropertiesRuntype = PartialRT({
 })
 type TagCategoryProperties = Static<typeof TagCategoryPropertiesRuntype>
 
-type TagCategorySections = {
+type TagCategorySection = {
   name?: string
   description?: string
   tags: TagDefinitions
-}[]
+} & TagRelationships
 
 export type TagCategory = TagCategoryProperties & TagRelationships & {
   id: string
   tags: TagDefinitions
-  sections: TagCategorySections
+  sections: TagCategorySection[]
   _relationships?: string[]
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,16 +1,16 @@
 import { parse } from "toml"
 import {
-  Array as ArrayRuntype, Dictionary, Intersect, Number, Partial,
+  Array as ArrayRT, Dictionary, Intersect, Number, Partial as PartialRT,
   Static, String, Union
 } from "runtypes"
 
 /* Types for processed tag configuration objects */
 
-const TagRelationshipListRuntype = ArrayRuntype(
-  Union(String, ArrayRuntype(String))
+const TagRelationshipListRuntype = ArrayRT(
+  Union(String, ArrayRT(String))
 )
 
-const TagRelationshipsRuntype = Partial({
+const TagRelationshipsRuntype = PartialRT({
   requires: TagRelationshipListRuntype,
   similar: TagRelationshipListRuntype,
   related: TagRelationshipListRuntype,
@@ -18,12 +18,12 @@ const TagRelationshipsRuntype = Partial({
   conflicts: TagRelationshipListRuntype,
   supersedes: TagRelationshipListRuntype,
   // Stores final relationships summary strings
-  _relationships: ArrayRuntype(String)
+  _relationships: ArrayRT(String)
 })
 type TagRelationships = Static<typeof TagRelationshipsRuntype>
 
 const TagRuntype = Intersect(
-  Partial({
+  PartialRT({
     'description': String,
     'description-plain': String
   }),
@@ -34,7 +34,7 @@ export type Tag = Static<typeof TagRuntype>
 const TagDefinitionsRuntype = Dictionary(TagRuntype, "string")
 type TagDefinitions = Static<typeof TagDefinitionsRuntype>
 
-const TagCategoryPropertiesRuntype = Partial({
+const TagCategoryPropertiesRuntype = PartialRT({
   name: String,
   description: String,
   max: Number
@@ -63,10 +63,10 @@ const TagCategoryCategoryConfigRuntype = Intersect(
   TagRelationshipsRuntype
 )
 
-const TagCategorySectionConfigRuntype = ArrayRuntype(
+const TagCategorySectionConfigRuntype = ArrayRT(
   Intersect(
     // Properties of the section
-    Partial({
+    PartialRT({
       name: String,
       description: String
     }),
@@ -87,7 +87,7 @@ const TagCategoryConfigRuntype = Intersect(
     "string"
   ),
   // Tag sections
-  Partial({ section: TagCategorySectionConfigRuntype })
+  PartialRT({ section: TagCategorySectionConfigRuntype })
 )
 
 /**

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -230,7 +230,7 @@ export function parseConfig (config: string): TagCategory {
   // Check that relationship properties do not have nested lists if they do not
   // support it
   Object.entries(<TagDefinitions>Object.assign(
-    {}, categoryTags, ...categorySections.map(s => s.tags)
+    {}, categoryTags, categorySections, ...categorySections.map(s => s.tags)
   )).forEach(([tagName, tag]) => {
     (<const>["similar", "related", "dissimilar", "supersedes"]).forEach(
       property => {

--- a/src/tags/README.md
+++ b/src/tags/README.md
@@ -31,7 +31,13 @@ Name | Description
 **description** | A description of this category and why it contains the tags it does.
 **max** | The maximum number of tags a page can have from this category.
 
-A category can be split up into sections. Sections do not affect the functionality of tags, only the documentation. It is not possible to select an entire section of tags (unlike categories) in a tag relationship property.
+A category can be split up into sections. Sections are primarily intended
+to aid splitting up tag documentation for readability, but they can also be
+used to apply relationships to all tags in the section (just like a tag
+category).
+
+It is not possible to select an entire section of tags (unlike categories)
+in a tag relationship property.
 
 Create a new section with `[[section]]`. All tags that come after it, up until the next `[[section]]`, must be defined as `[section.<name of tag>]` (otherwise they will not be in the section). For example:
 
@@ -47,7 +53,8 @@ name = "More tags"
 [section.tag-2]
 ```
 
-Sections can have the following properties:
+In addition to defaults for the relationship properties below, sections can
+have the following properties:
 
 Name | Property
 --- | ---

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -79,4 +79,28 @@ describe("config parser", () => {
       }
     )
   })
+
+  it("supports relationships defined in sections", () => {
+    expect(parseConfig(`
+      ["category/"]
+      [tag-1]
+      [[section]]
+      requires = ["tag-1"]
+    `)).toEqual(
+      {
+        id: "category/",
+        name: undefined,
+        description: undefined,
+        tags: { "tag-1": {} },
+        sections: [
+          {
+            name: undefined,
+            description: undefined,
+            requires: ["tag-1"],
+            tags: {}
+          }
+        ]
+      }
+    )
+  })
 })

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -63,4 +63,20 @@ describe("config parser", () => {
       related = [["tag-2"]]
     `)).toThrow(ConfigParseError)
   })
+
+  it("supports relationships defined in categories", () => {
+    expect(parseConfig(`
+      ["category/"]
+      requires = [ "tag-1" ]
+    `)).toEqual(
+      {
+        id: "category/",
+        name: undefined,
+        description: undefined,
+        requires: ["tag-1"],
+        tags: {},
+        sections: []
+      }
+    )
+  })
 })


### PR DESCRIPTION
Category relationships (i.e. relationships that are set for all tags in a given category) already exist, but relationships for sections do not. This relegates sections to being purely cosmetic.

This PR aims to change that.