### PR TITLE
Replace CodeTabs with wikidot.croquembouche.net

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,16 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
     - name: Install
       run: npm install
+
     - name: Build
       run: npm run build
+
     - name: Test
       run: npm run tests
+
     - name: Deploy
       if: github.ref == 'refs/heads/main'
       uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,7 @@
 <main>
   <p>
-    This tool uses
-    <a href="https://codetabs.com/cors-proxy/cors-proxy.html">CodeTabs CORS Proxy</a>.
+    This tool uses the
+    <a href="https://wikidot.croquembouche.net/">wikidot.croquembouche.net CORS Proxy</a>.
   </p>
   <h2>1. Templates <span id="template-state"></span></h2>
 

--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,7 @@
 <main>
   <p>
     This tool uses the
-    <a href="https://wikidot.croquembouche.net/">wikidot.croquembouche.net CORS Proxy</a>.
+    <a href="https://wikidot.croquembouche.net/">wikidot.croquembouche.net</a> CORS Proxy.
   </p>
   <h2>1. Templates <span id="template-state"></span></h2>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,17 +272,16 @@ function makeDefinitionsList(): void {
  */
 async function fetchUrls(urls: string[]): Promise<string[]> {
   // A CORS proxy is required to access the code blocks.
-  // CodeTabs CORS Proxy is used here:
-  // https://codetabs.com/cors-proxy/cors-proxy.html
-  // This proxy has a limit of 5 requests per second, so a 200ms delay will be
-  // inserted between each request.
+  // The wikidot.croquembouche.net CORS proxy is used here.
+  // This proxy has a limit of 60 requests per 10 seconds per IP,
+  // so a 200ms delay will be inserted between each request.
   let delay = 0
   const delayIncrement = 200
   return await Promise.all(urls.map(async url => {
     delay += delayIncrement
     return new Promise(func => setTimeout(func, delay)).then(async () => {
       return await (
-        await fetch(`https://api.codetabs.com/v1/proxy/?quest=${url}`)
+        await fetch(`https://wikidot.croquembouche.net/?url=${encodeURIComponent(url)}`)
       ).text()
     })
   }))


### PR DESCRIPTION
CodeTabs is being sunset, and will no longer function. Croquembouche has set up [wikidot.croquembouche.net](https://wikidot.croquembouche.net/) as an alternative to use here.

Tested locally, ran the generator.