### PR TITLE
Migrate test suite to Vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,24 +9,18 @@
     "lint": "prettier --check . && eslint . && stylelint ./src/**/*.css",
     "lint:fix": "prettier --write . && eslint . --fix && stylelint ./src/**/*.css --fix",
     "format": "prettier --write .",
-    "tests": "jest"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "ts"
-    ]
+    "tests": "vitest run"
   },
   "browserslist": "last 5 years",
   "devDependencies": {
     "@types/ejs": "^3.1.5",
-    "@types/jest": "^30.0.0",
     "ejs": "^6.0.1",
     "prettier": "^3.9.5",
     "prettier-plugin-organize-imports": "^4.3.0",
     "runtypes": "6.7.0",
     "toml": "^4.1.2",
     "typescript": "^6.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.4",
+    "vitest": "^4.1.10"
   }
 }

--- a/tests/documentation.spec.ts
+++ b/tests/documentation.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest"
 import { makeRelationshipsStringsForTag } from "../src/documentation"
 import { getTargets } from "../src/documentation"
 import { TagCategory } from "../src/parser"

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest"
 import { parseConfig, TomlParseError, ConfigParseError } from "../src/parser"
 
 describe("config parser", () => {


### PR DESCRIPTION
Replaces jest test runner with Vitest, removes obsolete jest configs and dependencies. Imports vitest APIs