### PR TITLE
Set vite base for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  // due to being hosted on GitHub Pages
+  // URL is of form scpwiki.github.io/tag-list
+  base: '/tag-list'
+})


### PR DESCRIPTION
Currently seeing this:
<img width="515" height="54" alt="image" src="https://github.com/user-attachments/assets/1524b90a-be4e-4045-a60d-0cca7fc27f8a" />

This is due to Vite assuming it's hosted at the root, `/`, but GitHub Pages has the structure of `org-name.github.io/repo-name`, so we need it to be relative to `/tag-list` instead.